### PR TITLE
fix: return books list from collection endpoint

### DIFF
--- a/book_api/routers/books.py
+++ b/book_api/routers/books.py
@@ -16,8 +16,8 @@ book = APIRouter()
 
 @book.get("/books/", summary="Get all books")
 async def read_books(db: Session = Depends(get_db)):
-    users = get_books(db)
-    return users
+    books_list = get_books(db)
+    return books_list
 
 
 @book.get(


### PR DESCRIPTION
## Summary
- rename temporary variable used in /books list handler for clarity
- ensure the endpoint returns the books collection instead of an unrelated name

## Testing
- not run (per instruction)